### PR TITLE
Allow a client application to set the default stack ClassLoader.

### DIFF
--- a/stack-core/src/main/java/com/digitalpetri/opcua/stack/core/Stack.java
+++ b/stack-core/src/main/java/com/digitalpetri/opcua/stack/core/Stack.java
@@ -16,6 +16,7 @@
 
 package com.digitalpetri.opcua.stack.core;
 
+import java.net.URLClassLoader;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -24,9 +25,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.digitalpetri.opcua.stack.core.util.ManifestUtil;
+
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
+
 import org.slf4j.LoggerFactory;
 
 public final class Stack {
@@ -44,6 +47,7 @@ public final class Stack {
     private static ExecutorService EXECUTOR_SERVICE;
     private static ScheduledExecutorService SCHEDULED_EXECUTOR_SERVICE;
     private static HashedWheelTimer WHEEL_TIMER;
+    private static ClassLoader DEFAULT_CLASS_LOADER;
 
     /**
      * @return a shared {@link NioEventLoopGroup}.
@@ -169,4 +173,29 @@ public final class Stack {
         }
     }
 
+    /**
+     * Set the default class loader.
+     * A client application may call this method to pass a specific {@link ClassLoader} to the {@link Stack}.
+     * Otherwise the default class loader will be the {@link Stack} class loader.
+     * The method should be called only once before any other stack operation.
+     * Currently only {@link URLClassLoader} and only file:// URLs are supported.
+     * 
+     * @param classLoader the default class loader to be used by the stack.
+     */
+    public static synchronized void setDefaultClassLoader(ClassLoader classLoader) {
+    	DEFAULT_CLASS_LOADER = classLoader;
+    }
+    
+    /**
+     * Get the default class loader.
+     * The stack will use the default {@link ClassLoader} to find and load classes.
+     * 
+     * @return the default class loader to be used by the stack.
+     */
+    public static synchronized ClassLoader getDefaultClassLoader() {
+    	if (DEFAULT_CLASS_LOADER == null) {
+    		DEFAULT_CLASS_LOADER = Stack.class.getClassLoader();
+    	}
+    	return DEFAULT_CLASS_LOADER;
+    }
 }

--- a/stack-core/src/main/java/com/digitalpetri/opcua/stack/core/serialization/DelegateRegistry.java
+++ b/stack-core/src/main/java/com/digitalpetri/opcua/stack/core/serialization/DelegateRegistry.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
+import com.digitalpetri.opcua.stack.core.Stack;
 import com.digitalpetri.opcua.stack.core.StatusCodes;
 import com.digitalpetri.opcua.stack.core.UaSerializationException;
 import com.digitalpetri.opcua.stack.core.types.builtin.NodeId;
@@ -27,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.ClassPath;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,7 +128,7 @@ public class DelegateRegistry {
         Logger logger = LoggerFactory.getLogger(DelegateRegistry.class);
 
         try {
-            ClassLoader classLoader = DelegateRegistry.class.getClassLoader();
+            ClassLoader classLoader = Stack.getDefaultClassLoader();
             ClassPath classPath = ClassPath.from(classLoader);
 
             ImmutableSet<ClassPath.ClassInfo> structures =
@@ -139,6 +141,7 @@ public class DelegateRegistry {
                 Class<?> clazz = classInfo.load();
 
                 try {
+                	logger.debug("Loading class: {}", clazz);
                     Class.forName(clazz.getName(), true, classLoader);
                 } catch (Exception e) {
                     logger.error("Error loading class: {}", clazz, e);


### PR DESCRIPTION
This allows the opcua stack to be used in Java frameworks,
like OSGi, that use special class loaders.

The simplest (not the best) way to use opcua with OSGi is to copy the needed jars in a `lib/opcua/` directory in the bundle using it. In this case the bundle may create a suitable class loader for the opcua stack like this:

```
    private static void initializeStackClassLoader(Bundle bundle) {
        try {
            URL url = bundle.getEntry("/lib/opcua/stack-core-1.0.3-SNAPSHOT.jar");
            URL fileUrl = FileLocator.toFileURL(url);
            ClassLoader classLoader = new URLClassLoader(new URL[] {fileUrl},
                    IiotDemoKit.class.getClassLoader());
            Stack.setDefaultClassLoader(classLoader);
        } catch (IOException e) {
            e.printStackTrace();
        }
    }
```

It would be nice to add an OSGi version of the tests. I'll see what I can do.
